### PR TITLE
[FT-716] Don't detect source based on document referrer

### DIFF
--- a/src/tracking.test.ts
+++ b/src/tracking.test.ts
@@ -26,36 +26,14 @@ describe('tracking', () => {
    * @jest-environment-options {"url": "https://jestjs.io/"}
    */
   describe('getTrafficSource()', () => {
-    [
-      'https://www.google.com',
-      'https://www.bing.com',
-      'https://www.google.com/bka/lba?dsad',
-      'https://www.yahoo.com/dsa/cas',
-    ].forEach((testReferrer) => {
-      it(`should return organic: ${testReferrer}`, () => {
-        // Arrange
-        jest.spyOn(document, 'referrer', 'get').mockReturnValue(testReferrer);
-        jest.spyOn(tracking, 'getQueryParam').mockReturnValue(null);
-
-        // Act
-        const detectedSource = tracking.getTrafficSource();
-
-        // Assert
-        expect(detectedSource).toBe('organic');
-      });
-    });
-
-    it(`should return value of 'source'`, () => {
+    it(`should return the source query param when it is present`, () => {
       // Arrange
       jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://www.google.com/');
       jest.spyOn(tracking, 'getQueryParam').mockImplementation((key: string): string | null => {
-        if (key == 'af') {
-          return '0x1234';
-        }
-
-        if (key == 'source') {
+        if (key === 'source') {
           return 'some-source';
         }
+        
         return null;
       });
 
@@ -66,52 +44,22 @@ describe('tracking', () => {
       expect(detectedSource).toBe('some-source');
     });
 
-    it(`should return affiliate`, () => {
+    it(`should return undefined when the source query param is not present`, () => {
       // Arrange
       jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://www.google.com/');
       jest.spyOn(tracking, 'getQueryParam').mockImplementation((key: string): string | null => {
-        if (key == 'af') {
-          return '0x1234';
+        if (key === 'source') {
+          return null;
         }
-        return null;
+        
+        throw new Error(`Unexpected key: ${key}`);
       });
 
       // Act
       const detectedSource = tracking.getTrafficSource();
 
       // Assert
-      expect(detectedSource).toBe('affiliate');
-    });
-
-    it(`should return affiliate`, () => {
-      // Arrange
-      jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://www.google.com/');
-      jest.spyOn(tracking, 'getQueryParam').mockImplementation((key: string): string | null => {
-        if (key == 'af') {
-          return '0x1234';
-        }
-        return null;
-      });
-
-      // Act
-      const detectedSource = tracking.getTrafficSource();
-
-      // Assert
-      expect(detectedSource).toBe('affiliate');
-    });
-
-    it(`should return direct`, () => {
-      // Arrange
-      jest.spyOn(document, 'referrer', 'get').mockReturnValue('http://www.sarasa.com/');
-      jest.spyOn(tracking, 'getQueryParam').mockImplementation((): string | null => {
-        return null;
-      });
-
-      // Act
-      const detectedSource = tracking.getTrafficSource();
-
-      // Assert
-      expect(detectedSource).toBe('direct');
+      expect(detectedSource).toBeUndefined()
     });
   });
 });

--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -2,8 +2,6 @@ import { nanoid } from 'nanoid';
 
 const TRACKING_ID_KEY = 'fuul.tracking_id';
 
-const SEARCH_ENGINE_URLS = ['google.com', 'bing.com', 'yahoo.com'];
-
 export const getTrackingId = () => getStoredOrcurrent(TRACKING_ID_KEY, () => nanoid());
 export const getAffiliateId = () => getQueryParam('af') || getQueryParam('referrer');
 export const getReferrerUrl = () => document.referrer;
@@ -33,32 +31,9 @@ export const getQueryParam = (key: string) => {
   return queryParams.get(key);
 };
 
-export const detectSource = (): string => {
-  const source = getQueryParam('source');
-  const affiliate = getQueryParam('af') || getQueryParam('referrer');
-
-  if (source) {
-    return source;
-  }
-
-  if (affiliate) {
-    return 'affiliate';
-  }
-
-  const domain = extractDomain(document.referrer);
-  if (domain && SEARCH_ENGINE_URLS.includes(domain)) {
-    return 'organic';
-  }
-
-  return 'direct';
-};
-
-const extractDomain = (urlString: string): string | null => {
-  try {
-    const url = new URL(urlString);
-    const domain = url.hostname?.split('.').slice(-2).join('.');
-    return domain;
-  } catch (e) {
-    return null;
+export const detectSource = (): string | undefined => {
+  const sourceParam = getQueryParam('source');
+  if (sourceParam) {
+    return sourceParam;
   }
 };


### PR DESCRIPTION
## What

Fix source for non-organic referrers

Return referrer's domain instead of "direct"


## Checklist

- [x] Code has been tested
- [x] Documentation has been updated (if applicable)