### PR TITLE
Add get user points and points leaderboard methods

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@fuul/sdk",
-  "version": "3.3.3",
+  "version": "3.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@fuul/sdk",
-      "version": "3.3.3",
+      "version": "3.4.1",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.2.2",

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -246,25 +246,117 @@ describe('SDK core', () => {
     });
   });
 
-  describe('getUserPayouts()', () => {
+  describe('getUserPayoutsByConversion()', () => {
     beforeEach(() => {
       Fuul.init({ apiKey: 'test-key' });
     });
 
-    it('should call getUserPayouts with correct arguments', async () => {
-      const getUserPayoutsSpy = jest.spyOn(PayoutService.prototype, 'getUserPayouts').mockResolvedValueOnce({
+    it('should call getUserPayoutsByConversion with correct arguments', async () => {
+      const getUserPayoutsByConversionSpy = jest.spyOn(PayoutService.prototype, 'getUserPayoutsByConversion').mockResolvedValueOnce({
+        page: 1,
+        page_size: 10,
+        total_results: 100,
+        results: [
+          {
+            is_referrer: true,
+            total_amount: '100',
+            conversion_id: 'conversion-1',
+            conversion_name: 'buy',
+            currency_address: '0x1',
+            chain_id: 1,
+          }
+        ],
+      })
+  
+      const payouts = await Fuul.getUserPayoutsByConversion({
+        user_address: '0x123'
+      })
+  
+      expect(getUserPayoutsByConversionSpy).toHaveBeenCalledWith({
+        user_address: '0x123'
+      })
+  
+      expect(payouts).toEqual({
+        page: 1,
+        page_size: 10,
+        total_results: 100,
+        results: [
+          {
+            is_referrer: true,
+            total_amount: '100',
+            conversion_id: 'conversion-1',
+            conversion_name: 'buy',
+            currency_address: '0x1',
+            chain_id: 1,
+          }
+        ]
+      })
+    })
+  })
+
+  describe('getUserPointsByConversion()', () => {
+    beforeEach(() => {
+      Fuul.init({ apiKey: 'test-key' });
+    });
+
+    it('should call getUserPointsByConversion with correct arguments', async () => {
+      const getUserPointsByConversionSpy = jest.spyOn(PayoutService.prototype, 'getUserPointsByConversion').mockResolvedValueOnce({
+        page: 1,
+        page_size: 10,
+        total_results: 100,
+        results: [
+          {
+            is_referrer: true,
+            total_amount: '100',
+            conversion_id: 'conversion-1',
+            conversion_name: 'buy',
+          }
+        ],
+      })
+  
+      const payouts = await Fuul.getUserPointsByConversion({
+        user_address: '0x123'
+      })
+  
+      expect(getUserPointsByConversionSpy).toHaveBeenCalledWith({
+        user_address: '0x123',
+      })
+  
+      expect(payouts).toEqual({
+        page: 1,
+        page_size: 10,
+        total_results: 100,
+        results: [
+          {
+            is_referrer: true,
+            total_amount: '100',
+            conversion_id: 'conversion-1',
+            conversion_name: 'buy',
+          }
+        ]
+      })
+    })
+  })
+
+  describe('getPayoutsLeaderboard()', () => {
+    beforeEach(() => {
+      Fuul.init({ apiKey: 'test-key' });
+    });
+    
+    it('should call getPayoutsLeaderboard with correct arguments', async () => {
+      const getPayoutsLeaderboardSpy = jest.spyOn(PayoutService.prototype, 'getPayoutsLeaderboard').mockResolvedValueOnce({
         page: 1,
         page_size: 10,
         total_results: 100,
         results: [],
       })
   
-      const payouts = await Fuul.getUserPayouts({
-        user_address: '0x123'
+      const payouts = await Fuul.getPayoutsLeaderboard({
+        currency_address: '0x123'
       })
   
-      expect(getUserPayoutsSpy).toHaveBeenCalledWith({
-        user_address: '0x123'
+      expect(getPayoutsLeaderboardSpy).toHaveBeenCalledWith({
+        currency_address: '0x123'
       })
   
       expect(payouts).toEqual({
@@ -276,25 +368,27 @@ describe('SDK core', () => {
     })
   })
 
-  describe('getProjectPayoutsLeaderboard()', () => {
+  describe('getPointsLeaderboard()', () => {
     beforeEach(() => {
       Fuul.init({ apiKey: 'test-key' });
     });
     
-    it('should call getProjectPayoutsLeaderboard with correct arguments', async () => {
-      const getProjectPayoutsLeaderboardSpy = jest.spyOn(PayoutService.prototype, 'getProjectPayoutsLeaderboard').mockResolvedValueOnce({
+    it('should call getPointsLeaderboard with correct arguments', async () => {
+      const getPointsLeaderboardSpy = jest.spyOn(PayoutService.prototype, 'getPointsLeaderboard').mockResolvedValueOnce({
         page: 1,
         page_size: 10,
         total_results: 100,
         results: [],
       })
   
-      const payouts = await Fuul.getProjectPayoutsLeaderboard({
-        currency_address: '0x123'
+      const payouts = await Fuul.getPointsLeaderboard({
+        page: 1,
+        page_size: 10,
       })
   
-      expect(getProjectPayoutsLeaderboardSpy).toHaveBeenCalledWith({
-        currency_address: '0x123'
+      expect(getPointsLeaderboardSpy).toHaveBeenCalledWith({
+        page: 1,
+        page_size: 10,
       })
   
       expect(payouts).toEqual({

--- a/src/core.ts
+++ b/src/core.ts
@@ -12,7 +12,7 @@ import {
   getTrafficTag,
   getTrafficTitle,
 } from './tracking';
-import { Conversion, FuulEvent, GetProjectPayoutsLeaderboardParams, GetUserPayoutsParams, ProjectPayoutsLeaderboardResponse, UserPayoutsResponse } from './types/api';
+import { Conversion, FuulEvent, GetPayoutsLeaderboardParams, GetPointsLeaderboardParams, GetUserPayoutsByConversionParams, GetUserPointsByConversionParams, LeaderboardResponse, PayoutsLeaderboard, PointsLeaderboard, UserPayoutsByConversionResponse, UserPointsByConversionResponse } from './types/api';
 import { AffiliateLinkParams, EventArgs, FuulSettings, UserMetadata } from './types/sdk';
 
 const FUUL_API_DEFAULT_ENDPOINT_URI = 'https://api.fuul.xyz/api/v1/';
@@ -251,28 +251,54 @@ export async function generateTrackingLink(
 
 /**
  * Gets the project payouts leaderboard
- * @param {GetProjectPayoutsLeaderboardParams} params The search params
- * @returns {ProjectPayoutsLeaderboardResponse} Project payouts leaderboard
+ * @param {GetPayoutsLeaderboardParams} params The search params
+ * @returns {LeaderboardResponse<PayoutsLeaderboard>} Payouts leaderboard response
  * @example
  * ```typescript
- * const results = await Fuul.getProjectPayoutsLeaderboard({ currency_address: '0x12345' }});
+ * const results = await Fuul.getPayoutsLeaderboard({ currency_address: '0x12345' }});
  * ```
  **/
-export function getProjectPayoutsLeaderboard(params: GetProjectPayoutsLeaderboardParams): Promise<ProjectPayoutsLeaderboardResponse> {
-  return _payoutService.getProjectPayoutsLeaderboard(params);
+export function getPayoutsLeaderboard(params: GetPayoutsLeaderboardParams): Promise<LeaderboardResponse<PayoutsLeaderboard>> {
+  return _payoutService.getPayoutsLeaderboard(params);
 }
 
 /**
- * Gets the project payouts leaderboard
- * @param {GetUserPayoutsParams} params The search params
- * @returns {UserPayoutsResponse} Project payouts leaderboard
+ * Gets the project points leaderboard
+ * @param {GetPointsLeaderboardParams} params The search params
+ * @returns {LeaderboardResponse<PointsLeaderboard>} Points leaderboard response
  * @example
  * ```typescript
- * const results = await Fuul.getUserPayouts({ user_address: '0x12345' }});
+ * const results = await Fuul.getPointsLeaderboard({ currency_address: '0x12345' }});
  * ```
  **/
-export function getUserPayouts(params: GetUserPayoutsParams): Promise<UserPayoutsResponse> {
-  return _payoutService.getUserPayouts(params);
+export function getPointsLeaderboard(params: GetPointsLeaderboardParams): Promise<LeaderboardResponse<PointsLeaderboard>> {
+  return _payoutService.getPointsLeaderboard(params);
+}
+
+/**
+ * Gets the user payouts by conversion
+ * @param {GetUserPayoutsByConversionParams} params The search params
+ * @returns {UserPayoutsByConversionResponse} User payouts by conversion
+ * @example
+ * ```typescript
+ * const results = await Fuul.getUserPayoutsByConversion({ user_address: '0x12345' }});
+ * ```
+ **/
+export function getUserPayoutsByConversion(params: GetUserPayoutsByConversionParams): Promise<UserPayoutsByConversionResponse> {
+  return _payoutService.getUserPayoutsByConversion(params);
+}
+
+/**
+ * Gets user points by conversion
+ * @param {GetUserPointsByConversionParams} params The search params
+ * @returns {UserPointsByConversionResponse} User points by conversion
+ * @example
+ * ```typescript
+ * const results = await Fuul.getUserPointsByConversion({ user_address: '0x12345' }});
+ * ```
+ **/
+export function getUserPointsByConversion(params: GetUserPointsByConversionParams): Promise<UserPointsByConversionResponse> {
+  return _payoutService.getUserPointsByConversion(params);
 }
 
 export async function getConversions(): Promise<Conversion[]> {
@@ -312,6 +338,8 @@ export default {
   updateAffiliateCode,
   getAffiliateCode,
   isAffiliateCodeFree,
-  getUserPayouts,
-  getProjectPayoutsLeaderboard,
+  getPayoutsLeaderboard,
+  getPointsLeaderboard,
+  getUserPayoutsByConversion,
+  getUserPointsByConversion
 };

--- a/src/payouts/PayoutService.ts
+++ b/src/payouts/PayoutService.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '../HttpClient';
-import { GetProjectPayoutsLeaderboardParams, GetUserPayoutsParams, ProjectPayoutsLeaderboardResponse, UserPayoutsResponse } from '../types/api';
+import {  GetPayoutsLeaderboardParams, GetPointsLeaderboardParams, GetUserPayoutsByConversionParams, GetUserPointsByConversionParams, LeaderboardResponse, PayoutsLeaderboard, PointsLeaderboard, UserPayoutsByConversionResponse, UserPointsByConversionResponse} from '../types/api';
 
 export type PayoutServiceSettings = {
   httpClient: HttpClient;
@@ -17,13 +17,23 @@ export class PayoutService {
     this._debug = settings.debug;
   }
 
-  public async getProjectPayoutsLeaderboard(params: GetProjectPayoutsLeaderboardParams): Promise<ProjectPayoutsLeaderboardResponse> {
-    const results = await this.httpClient.get<ProjectPayoutsLeaderboardResponse>(`${basePath}/leaderboard`, params);
+  public async getPayoutsLeaderboard(params: GetPayoutsLeaderboardParams): Promise<LeaderboardResponse<PayoutsLeaderboard>> {
+    const results = await this.httpClient.get<LeaderboardResponse<PayoutsLeaderboard>>(`${basePath}/leaderboard`, params);
     return results.data;
   }
 
-  public async getUserPayouts(params: GetUserPayoutsParams): Promise<UserPayoutsResponse> {
-    const results = await this.httpClient.get<UserPayoutsResponse>(basePath, params);
+  public async getPointsLeaderboard(params: GetPointsLeaderboardParams): Promise<LeaderboardResponse<PointsLeaderboard>> {
+    const results = await this.httpClient.get<LeaderboardResponse<PointsLeaderboard>>(`${basePath}/leaderboard`, params);
+    return results.data;
+  }
+
+  public async getUserPayoutsByConversion(params: GetUserPayoutsByConversionParams): Promise<UserPayoutsByConversionResponse> {
+    const results = await this.httpClient.get<UserPayoutsByConversionResponse>(basePath, {...params, type: 'onchain-currency' });
+    return results.data;
+  }
+
+  public async getUserPointsByConversion(params: GetUserPointsByConversionParams): Promise<UserPointsByConversionResponse> {
+    const results = await this.httpClient.get<UserPointsByConversionResponse>(basePath, {...params, type: 'point' });
     return results.data;
   }
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -194,42 +194,77 @@ export interface Conversion {
   };
 }
 
-export interface GetProjectPayoutsLeaderboardParams {
-  currency_address: string;
+export interface GetPayoutsLeaderboardParams {
+  currency_address?: string;
   page?: number;
   page_size?: number;
 }
 
-export interface ProjectPayoutsLeaderboardResponse {
+export interface GetPointsLeaderboardParams {
+  page?: number;
+  page_size?: number;
+}
+
+export interface LeaderboardResponse<T> {
   total_results: number;
   page: number;
   page_size: number;
-  results: ProjectPayoutsLeaderboardResponseResult[];
+  results: T[];
 }
 
-export interface ProjectPayoutsLeaderboardResponseResult {
+export interface PayoutsLeaderboard {
   address: string;
-  total_paid: number;
+  total_amount: string;
+  chain_id: number;
+  rank: number;
 }
 
-export interface GetUserPayoutsParams {
+export interface PointsLeaderboard {
+  address: string;
+  total_amount: string;
+  rank: number;
+}
+
+export interface GetUserPayoutsByConversionParams {
   user_address: string;
   page?: number;
   page_size?: number;
   group_by?: string;
 }
 
-export interface UserPayoutsResponse {
+export interface GetUserPointsByConversionParams {
+  user_address: string;
+  page?: number;
+  page_size?: number;
+  group_by?: string;
+}
+
+export interface UserPayoutsByConversionResponse {
   total_results: number;
   page: number;
   page_size: number;
-  results: UserPayoutsResponseResult[];
+  results: UserConversionPayout[];
 }
 
-export interface UserPayoutsResponseResult {
+export interface UserConversionPayout {
   is_referrer: boolean;
-  total_paid: number;
+  total_amount: string;
+  conversion_id: string;
+  conversion_name: string;
   currency_address: string;
-  conversion_id?: string;
-  conversion_name?: string;
+  chain_id: number;
+}
+
+export interface UserPointsByConversionResponse {
+  total_results: number;
+  page: number;
+  page_size: number;
+  results: UserConversionPoints[];
+}
+
+export interface UserConversionPoints {
+  is_referrer: boolean;
+  total_amount: string;
+  conversion_id: string;
+  conversion_name: string;
 }


### PR DESCRIPTION
## What

Changes:
* Rename `getUserPayouts` to `getUserPayoutsByConversion`
* Rename `getProjectPayoutsLeaderboard` to `getPayoutsLeaderboard`
* Rename `total_paid` to `total_amount` in `getPayoutsLeaderboard` and `getPointsLeaderboard` response
* Add `rank` to `getPayoutsLeaderboard` and `getPointsLeaderboard` response

Added:
* Add `getUserPointsByConversion`
* Add `user_address` filter to `getPayoutsLeaderboard` and `getPointsLeaderboard` methods

## Checklist

- [x] Code has been tested
- [x] Documentation has been updated (if applicable)