### PR TITLE
Add getRewardsLeaderboard

### DIFF
--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -349,60 +349,26 @@ describe('SDK core', () => {
     });
   });
 
-  describe('getPayoutsLeaderboard()', () => {
+  describe('getRewardsLeaderboard()', () => {
     beforeEach(() => {
       Fuul.init({ apiKey: 'test-key' });
     });
 
-    it('should call getPayoutsLeaderboard with correct arguments', async () => {
-      const getPayoutsLeaderboardSpy = jest.spyOn(LeaderboardService.prototype, 'getPayoutsLeaderboard').mockResolvedValueOnce({
+    it('should call getRewardsLeaderboard with correct arguments', async () => {
+      const getRewardsLeaderboardSpy = jest.spyOn(LeaderboardService.prototype, 'getRewardsLeaderboard').mockResolvedValueOnce({
         page: 1,
         page_size: 10,
         total_results: 100,
         results: [],
       });
 
-      const payouts = await Fuul.getPayoutsLeaderboard({
+      const payouts = await Fuul.getRewardsLeaderboard({
         currency_address: '0x123',
         user_type: 'affiliate',
       });
 
-      expect(getPayoutsLeaderboardSpy).toHaveBeenCalledWith({
+      expect(getRewardsLeaderboardSpy).toHaveBeenCalledWith({
         currency_address: '0x123',
-        user_type: 'affiliate',
-      });
-
-      expect(payouts).toEqual({
-        page: 1,
-        page_size: 10,
-        total_results: 100,
-        results: [],
-      });
-    });
-  });
-
-  describe('getPointsLeaderboard()', () => {
-    beforeEach(() => {
-      Fuul.init({ apiKey: 'test-key' });
-    });
-
-    it('should call getPointsLeaderboard with correct arguments', async () => {
-      const getPointsLeaderboardSpy = jest.spyOn(LeaderboardService.prototype, 'getPointsLeaderboard').mockResolvedValueOnce({
-        page: 1,
-        page_size: 10,
-        total_results: 100,
-        results: [],
-      });
-
-      const payouts = await Fuul.getPointsLeaderboard({
-        page: 1,
-        page_size: 10,
-        user_type: 'affiliate',
-      });
-
-      expect(getPointsLeaderboardSpy).toHaveBeenCalledWith({
-        page: 1,
-        page_size: 10,
         user_type: 'affiliate',
       });
 
@@ -418,7 +384,7 @@ describe('SDK core', () => {
   describe('getReferredUsersLeaderboard()', () => {
     beforeEach(() => {
       Fuul.init({ apiKey: 'test-key' });
-    })
+    });
 
     it('should call getReferredUsersLeaderboard with correct arguments', async () => {
       const getReferredUsersLeaderboardSpy = jest.spyOn(LeaderboardService.prototype, 'getReferredUsersLeaderboard').mockResolvedValueOnce({
@@ -435,7 +401,7 @@ describe('SDK core', () => {
             address: '0x124',
             rank: 2,
             total_referred_users: 9,
-          }
+          },
         ],
       });
 
@@ -463,9 +429,9 @@ describe('SDK core', () => {
             address: '0x124',
             rank: 2,
             total_referred_users: 9,
-          }
+          },
         ],
       });
     });
-  })
+  });
 });

--- a/src/core.ts
+++ b/src/core.ts
@@ -10,9 +10,8 @@ import {
   Conversion,
   FuulEvent,
   GetConversionsParams,
-  GetPayoutsLeaderboardParams,
-  GetPointsLeaderboardParams,
   GetReferredUsersLeaderboardParams,
+  GetRewardsLeaderboardParams,
   GetUserAudiencesParams,
   GetUserAudiencesResponse,
   GetUserPayoutMovementsParams,
@@ -21,9 +20,8 @@ import {
   GetUserPointsMovementsParams,
   GetVolumeLeaderboardParams,
   LeaderboardResponse,
-  PayoutsLeaderboard,
-  PointsLeaderboard,
   ReferredUsersLeaderboard,
+  RewardsLeaderboard,
   UserPayoutMovementsResponse,
   UserPayoutsByConversionResponse,
   UserPointsByConversionResponse,
@@ -299,29 +297,16 @@ export async function generateTrackingLink(baseUrl: string, affiliateAddress: st
 }
 
 /**
- * Gets the project payouts leaderboard
- * @param {GetPayoutsLeaderboardParams} params The search params
- * @returns {LeaderboardResponse<PayoutsLeaderboard>} Payouts leaderboard response
+ * Gets the project rewards leaderboard
+ * @param {GetRewardsLeaderboardParams} params The search params
+ * @returns {LeaderboardResponse<RewardsLeaderboard>} Rewards leaderboard response
  * @example
  * ```typescript
- * const results = await Fuul.getPayoutsLeaderboard({ currency_address: '0x12345', page: 1, page_size: 10 });
+ * const results = await Fuul.getRewardsLeaderboard({ currency_address: '0x12345', page: 1, page_size: 10 });
  * ```
  **/
-export function getPayoutsLeaderboard(params: GetPayoutsLeaderboardParams): Promise<LeaderboardResponse<PayoutsLeaderboard>> {
-  return _leaderboardService.getPayoutsLeaderboard(params);
-}
-
-/**
- * Gets the project points leaderboard
- * @param {GetPointsLeaderboardParams} params The search params
- * @returns {LeaderboardResponse<PointsLeaderboard>} Points leaderboard response
- * @example
- * ```typescript
- * const results = await Fuul.getPointsLeaderboard({ currency_address: '0x12345', page: 1, page_size: 10 });
- * ```
- **/
-export function getPointsLeaderboard(params: GetPointsLeaderboardParams): Promise<LeaderboardResponse<PointsLeaderboard>> {
-  return _leaderboardService.getPointsLeaderboard(params);
+export function getRewardsLeaderboard(params: GetRewardsLeaderboardParams): Promise<LeaderboardResponse<RewardsLeaderboard>> {
+  return _leaderboardService.getRewardsLeaderboard(params);
 }
 
 /**
@@ -482,8 +467,7 @@ export default {
   updateAffiliateCode,
   getAffiliateCode,
   isAffiliateCodeFree,
-  getPayoutsLeaderboard,
-  getPointsLeaderboard,
+  getRewardsLeaderboard,
   getReferredUsersLeaderboard,
   getUserAudiences,
   getUserPayoutsByConversion,

--- a/src/leaderboard/LeaderboardService.ts
+++ b/src/leaderboard/LeaderboardService.ts
@@ -1,12 +1,10 @@
 import { HttpClient } from '../HttpClient';
 import {
-  GetPayoutsLeaderboardParams,
-  GetPointsLeaderboardParams,
   GetReferredUsersLeaderboardParams,
+  GetRewardsLeaderboardParams,
   LeaderboardResponse,
-  PayoutsLeaderboard,
-  PointsLeaderboard,
   ReferredUsersLeaderboard,
+  RewardsLeaderboard,
 } from '../types/api';
 
 export type LeaderboardServiceSettings = {
@@ -20,17 +18,9 @@ export class LeaderboardService {
     this.httpClient = settings.httpClient;
   }
 
-  public async getPayoutsLeaderboard(params: GetPayoutsLeaderboardParams): Promise<LeaderboardResponse<PayoutsLeaderboard>> {
-    const results = await this.httpClient.get<LeaderboardResponse<PayoutsLeaderboard>>({
-      path: `/payouts/leaderboard/payouts`,
-      queryParams: { ...params },
-    });
-    return results.data;
-  }
-
-  public async getPointsLeaderboard(params: GetPointsLeaderboardParams): Promise<LeaderboardResponse<PointsLeaderboard>> {
-    const results = await this.httpClient.get<LeaderboardResponse<PointsLeaderboard>>({
-      path: `/payouts/leaderboard/points`,
+  public async getRewardsLeaderboard(params: GetRewardsLeaderboardParams): Promise<LeaderboardResponse<RewardsLeaderboard>> {
+    const results = await this.httpClient.get<LeaderboardResponse<RewardsLeaderboard>>({
+      path: `/rewards/leaderboard`,
       queryParams: { ...params },
     });
     return results.data;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -198,7 +198,7 @@ export interface Conversion {
 
 type LeaderboardUserType = 'affiliate' | 'end_user';
 
-export interface GetPayoutsLeaderboardParams {
+export interface GetRewardsLeaderboardParams {
   currency_address?: string;
   project_id?: string;
   user_address?: string;
@@ -208,23 +208,10 @@ export interface GetPayoutsLeaderboardParams {
   from?: Date;
   to?: Date;
   fields?: string;
-  conversions?: string;
+  conversion_external_id?: string;
 }
 
-export interface GetPointsLeaderboardParams {
-  currency_address?: string;
-  project_id?: string;
-  user_address?: string;
-  user_type?: LeaderboardUserType;
-  page?: number;
-  page_size?: number;
-  from?: Date;
-  to?: Date;
-  fields?: string;
-  conversions?: string;
-}
-
-export interface GetVolumeLeaderboardParams extends GetPayoutsLeaderboardParams {
+export interface GetVolumeLeaderboardParams extends GetRewardsLeaderboardParams {
   conversion_external_ids?: number[];
 }
 
@@ -235,11 +222,11 @@ export interface LeaderboardResponse<T> {
   results: T[];
 }
 
-export interface PayoutsLeaderboard {
+export interface RewardsLeaderboard {
   address: string;
   affiliate_code?: string;
   total_amount: string;
-  chain_id: number;
+  chain_id?: number;
   rank: number;
   total_attributions: number;
   tiers?: Record<string, string>;
@@ -253,16 +240,6 @@ export interface VolumeLeaderboard {
   total_amount: number;
   chain_id: number;
   rank: number;
-}
-
-export interface PointsLeaderboard {
-  address: string;
-  affiliate_code?: string;
-  total_amount: string;
-  rank: number;
-  total_attributions: number;
-  tiers?: Record<string, string>;
-  referred_volume?: string;
 }
 
 export interface ReferredUsersLeaderboard {


### PR DESCRIPTION
## What

* Remove the `getPointsLeaderboard` and `getPayoutsLeaderboard` in favor of the new `getRewardsLeaderboard` method. Without a `currency_address` param, the method will get the points rewards leaderboard for the project.

## Why

Unify points and onchain rewards leaderboard methods

## Checklist

- [x] Code has been tested
- [x] Documentation has been updated (if applicable)