### PR TITLE
[FT-3647] feat: save connect wallet event in local storage array

### DIFF
--- a/src/EventService.ts
+++ b/src/EventService.ts
@@ -86,10 +86,20 @@ export class EventService {
 
   private saveSentEvent(event: FuulEvent): void {
     const SENT_EVENT_KEY = `${SENT_EVENT_ID_KEY}_${event.name}`;
+    const SENT_EVENT_LIST_KEY = `${SENT_EVENT_KEY}_all`;
 
     const timestamp = this.getCurrentTimestamp();
     const eventParams = { ...event, timestamp };
 
     localStorage.setItem(SENT_EVENT_KEY, JSON.stringify(eventParams));
+
+    const existingList: FuulEvent[] = JSON.parse(localStorage.getItem(SENT_EVENT_LIST_KEY) || '[]');
+    const updatedList = [...existingList, eventParams];
+
+    const MAX_HISTORY = 10;
+    if (updatedList.length > MAX_HISTORY) {
+      updatedList.splice(0, updatedList.length - MAX_HISTORY);
+    }
+    localStorage.setItem(SENT_EVENT_LIST_KEY, JSON.stringify(updatedList));
   }
 }


### PR DESCRIPTION
## What
- Save "sent_connect_wallet" event in a new array slot in local storage, limited to 10 signatures to don't grow memory spacing.

## Why
- Need to save all wallets signed in the users browser to show "accept affiliate" modal

## Checklist
- [x] Code has been tested
- [ ] Documentation has been updated (if applicable)