### PR TITLE
Export BlockchainType from root

### DIFF
--- a/src/affiliates/AffiliateService.ts
+++ b/src/affiliates/AffiliateService.ts
@@ -1,7 +1,7 @@
 import { AxiosError } from 'axios';
 
+import { BlockchainType } from '..';
 import { HttpClient } from '../HttpClient';
-import { BlockchainType } from '../types';
 import { Affiliate } from '../types/api';
 import { AddressInUseError, CodeInUseError, InvalidSignatureError, ValidationError } from './errors';
 

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -16,10 +16,9 @@ jest.mock('nanoid', () => ({
   nanoid: () => '123',
 }));
 
-import { Fuul } from './index';
+import { BlockchainType, Fuul } from './index';
 import { LeaderboardService } from './leaderboard/LeaderboardService';
 import { PayoutService } from './payouts/PayoutService';
-import { BlockchainType } from './types';
 
 describe('SDK core', () => {
   beforeEach(() => {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,3 +1,4 @@
+import { BlockchainType } from '.';
 import { AffiliateService } from './affiliates/AffiliateService';
 import { AudienceService } from './audiences/AudienceService';
 import { ConversionService } from './ConversionService';
@@ -6,7 +7,6 @@ import { HttpClient } from './HttpClient';
 import { LeaderboardService } from './leaderboard/LeaderboardService';
 import { PayoutService } from './payouts/PayoutService';
 import { getAffiliateId, getReferrerUrl, getTrackingId, getTrafficCategory, getTrafficSource, getTrafficTag, getTrafficTitle } from './tracking';
-import { BlockchainType } from './types';
 import {
   Conversion,
   FuulEvent,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,11 @@ import Fuul from './core';
 
 export * from './affiliates/errors';
 export type { Conversion } from './types/api';
-export type { EventArgs, FuulSettings, ConnectWalletEventParams } from './types/sdk';
+export type { ConnectWalletEventParams, EventArgs, FuulSettings } from './types/sdk';
+
+export enum BlockchainType {
+  Ethereum = 'ethereum',
+  Solana = 'solana',
+}
 
 export { Fuul };

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,4 +1,4 @@
-import { BlockchainType } from '.';
+import { BlockchainType } from '..';
 
 export type FuulEventArgs = {
   [key: string]: unknown;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,0 @@
-export enum BlockchainType {
-  Ethereum = 'ethereum',
-  Solana = 'solana',
-}

--- a/src/types/sdk.ts
+++ b/src/types/sdk.ts
@@ -1,4 +1,4 @@
-import { BlockchainType } from '.';
+import { BlockchainType } from '..';
 
 export type FuulSettings = {
   debug?: boolean;


### PR DESCRIPTION
## What

Export `BlockchainType` from root

## Why

It's currently being exported in the internal path, which is incompatible with strict environments

