### PR TITLE
feat: add referral_code in referrer payouts response

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -632,6 +632,7 @@ export interface ReferrerPayoutData {
   date_joined: string;
   event_referrer_identifier: string;
   user_rebate_rate?: number | null;
+  referral_code: string | null;
 }
 
 export type PayoutsByReferrerResponse = Array<Record<string, ReferrerPayoutData>>;


### PR DESCRIPTION
## Description
Added `referral_code: string | null` field to the `ReferrerPayoutData` interface in `src/types/api.ts`.

This interface defines the shape of each referred user entry returned by `GET /api/v1/payouts/by-referrer`, consumed via:

- **Public API**: `Fuul.getPayoutsByReferrer()` (`src/core.ts`)
- **Service layer**: `PayoutService.getPayoutsByReferrer()` (`src/payouts/PayoutService.ts`)
- **Response type alias**: `PayoutsByReferrerResponse = Array<Record<string, ReferrerPayoutData>>` (`src/types/api.ts`)

No changes to request parameters, service logic, or HTTP calls. The field is always returned by the backend and is `null` when the user was attributed without a referral code.

## Why

The backend `by-referrer` endpoint now includes a `referral_code` field in each referred user entry. The SDK type needed to be updated so consumers can access this field with type safety instead of relying on untyped access.

## Test Plan
- [x] Tested locally
- `npm run lint` passes
- `npm run test:ci` passes (48 tests)
- `npm run build` produces `dist/index.mjs`, `dist/index.umd.js`, `dist/index.d.ts` successfully
- Verify `referral_code` appears in generated declaration file (`dist/index.d.ts`)

## Rollback Plan

Remove the `referral_code: string | null;` line from `ReferrerPayoutData` in `src/types/api.ts`. No data migration or side effects — the field is additive and read-only.

## Checklist
- [x] Code has been tested
- [x] No secrets or credentials included in this PR