### PR TITLE
feat: end user volume field

### DIFF
--- a/src/affiliate-portal/types/index.ts
+++ b/src/affiliate-portal/types/index.ts
@@ -31,6 +31,7 @@ export interface GetAffiliateStatsResponse {
   r3_volume: number;
   multilevel_volume: number;
   total_volume: number;
+  end_user_volume: number;
   referred_revenue: number;
   referred_users: number;
   status: AffiliateStatus;


### PR DESCRIPTION
## Description
Extends the `GetAffiliateStatsResponse` TypeScript interface in `src/affiliate-portal/types/index.ts` with a new `end_user_volume: number` field, aligning the SDK type contract with the updated response shape of `GET /api/v1/projects/:projectId/affiliate-portal/stats`.

- Type-only change: no service method, request params, or runtime logic modified.
- `AffiliatePortalService.getAffiliateStats` already forwards the full server payload; adding the field to the response interface is sufficient to expose it to SDK consumers with proper typing.
- The field honors the same date (`from` / `to` / `this_month`) and conversion (`conversion_external_id` / `conversion_name`) filters as the rest of the response — no new query params are introduced.

## Why

The server (see fuul-server PR #2750) now returns `end_user_volume`, the USD volume attributed to the user as an end user (their own trading activity), sourced from the `analytics.enduser_*_attribution_metrics_*_v2` tables. Without updating the SDK response interface, TypeScript consumers cannot access the field without casting, and the SDK's contract silently drifts from the server's OpenAPI spec.

## Test Plan

- [x] `npm run lint && npm run format` — passes
- [x] `npm run test:ci -- AffiliatePortalService.test.ts` — all 5 tests pass
- [x] `npm run build` — dual-format bundle (UMD + ESM) and `.d.ts` emit succeed; new field appears in generated declarations
- [x] Tested locally
- [x] Tested in staging

## Rollback Plan

Revert the single-line addition to `src/affiliate-portal/types/index.ts`. The change is purely additive at the type level — no runtime behavior, persisted state, or network contract depends on it, so rollback is safe and requires no data consideration. Consumers that start reading `end_user_volume` would lose type-level access but not runtime access to the field (the server still returns it).

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR