### PR TITLE
feat: update stats response

### DIFF
--- a/src/affiliate-portal/types/index.ts
+++ b/src/affiliate-portal/types/index.ts
@@ -1,8 +1,25 @@
+import { CurrentTier } from '../../types/api';
 import { UserIdentifierType } from '../../types/user';
 
 export type AffiliateStatus = 'Active' | 'Paused' | 'Flagged' | 'Terminated';
 
-export type AffiliateRegion = 'All' | 'CN' | 'JP' | 'KR' | 'SEA' | 'EN' | 'LATAM' | 'Other';
+export type AffiliateRegion =
+  | 'All'
+  | 'CN'
+  | 'JP'
+  | 'KR'
+  | 'SEA'
+  | 'IND'
+  | 'EN'
+  | 'LATAM'
+  | 'CIS'
+  | 'GE'
+  | 'SP'
+  | 'SA'
+  | 'EU'
+  | 'Other';
+
+export type AffiliatePortalTierView = CurrentTier;
 
 export interface GetAffiliateStatsParams {
   user_identifier: string;
@@ -25,14 +42,36 @@ export interface AffiliateEarning {
 export interface GetAffiliateStatsResponse {
   user_identifier: string;
   user_identifier_type: UserIdentifierType;
+  /**
+   * Movement-based commission totals per currency, across ALL referrer levels combined.
+   * Native token units (already divided by decimals). Includes POINT rewards.
+   */
   total_earnings: AffiliateEarning[];
+  /** USD volume attributed to this affiliate as the direct (L1) referrer. */
   referred_volume: number;
   r2_volume: number;
   r3_volume: number;
+  r4_volume: number;
+  /** Sum of r2_volume + r3_volume + r4_volume. */
   multilevel_volume: number;
+  /** referred_volume + multilevel_volume. */
   total_volume: number;
   end_user_volume: number;
+  /** USD attributed revenue for L1 direct referrals. */
   referred_revenue: number;
+  r2_revenue: number;
+  r3_revenue: number;
+  r4_revenue: number;
+  /** Count of L1 attribution events for this affiliate, scoped to the same date range as volumes. */
+  referred_attributions: number;
+  /** Confirmed payout commissions in USD for L1 (direct) referrals. Excludes POINT-denomination payouts. */
+  r1_earnings: number;
+  /** Confirmed payout commissions in USD for L2 referrals. Excludes POINT-denomination payouts. */
+  r2_earnings: number;
+  /** Confirmed payout commissions in USD for L3 referrals. Excludes POINT-denomination payouts. */
+  r3_earnings: number;
+  /** Confirmed payout commissions in USD for L4 referrals. Excludes POINT-denomination payouts. */
+  r4_earnings: number;
   /** Analytics-based referred-user count (existing semantics). Same value as `active_referrers`. */
   referred_users: number;
   /** Same as `referred_users` (analytics pipeline). */
@@ -44,6 +83,10 @@ export interface GetAffiliateStatsResponse {
   status: AffiliateStatus;
   region: AffiliateRegion | null;
   referral_codes: string[];
+  /** Tier after audience/default rules; no tier-protection overlay. */
+  effective_tier: AffiliatePortalTierView | null;
+  /** Tier shown to the affiliate; includes tier-protection overlay when active. */
+  current_tier: AffiliatePortalTierView | null;
 }
 
 export interface GetNewTradersParams {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import Fuul from './core';
 
 export type {
   AffiliateEarning,
+  AffiliatePortalTierView,
   AffiliateRegion,
   AffiliateStatus,
   DateRangePreset,


### PR DESCRIPTION
## Description
Updates the `GET /affiliate-portal/stats` response contract consumed by `AffiliatePortalService.getAffiliateStats` to match the backend changes introduced in `fuul-server@19fa9ba15`.

Changes are type-only; the service method already forwards every server-supported query param and returns the response payload as-is, so the new fields propagate through without runtime changes.

**`src/affiliate-portal/types/index.ts`**

- Added `AffiliatePortalTierView` as an alias of the existing `CurrentTier` interface in `src/types/api.ts` (`{ id, name, slug, rank }`) to avoid duplicating the tier shape.
- Extended `AffiliateRegion` union with the new server values: `IND`, `CIS`, `GE`, `SP`, `SA`, `EU`.
- Extended `GetAffiliateStatsResponse` with the new analytics fields:
  - `r4_volume` (USD).
  - `r2_revenue`, `r3_revenue`, `r4_revenue` (USD attributed revenue per level).
  - `referred_attributions` — L1 attribution event count, scoped to the same date range as volumes.
  - `r1_earnings`, `r2_earnings`, `r3_earnings`, `r4_earnings` — confirmed payout commissions per level in USD, sourced from analytics payout aggregates, excluding POINT-denomination payouts.
  - `effective_tier: AffiliatePortalTierView | null` — tier after audience/default rules, without tier-protection overlay.
  - `current_tier: AffiliatePortalTierView | null` — tier shown to the affiliate, including tier-protection overlay when active.

**`src/index.ts`**

- Exported `AffiliatePortalTierView` from the public type surface.

## Why

The backend commit `19fa9ba15` added per-level payout earnings, attribution counts, and re-added the `effective_tier` field on the affiliate portal stats endpoint, plus additional `AffiliateRegion` values. Without the type update, SDK consumers cannot access the new fields in a type-safe way and would have to cast the response.

`CurrentTier` already had the exact shape the backend's `AffiliatePortalTierView` returns, so the alias keeps a single source of truth instead of declaring a parallel interface.

## Test Plan

- [x] `npm run lint` — passes
- [x] `npx tsc --noEmit` — passes
- [x] `npx jest src/affiliate-portal/AffiliatePortalService.test.ts` — 6/6 tests pass
- [ ] Tested locally
- [ ] Tested in staging

Integration check: confirm a consumer can read `response.r1_earnings`, `response.effective_tier`, and `response.referred_attributions` from `Fuul.getAffiliateStats(...)` against a backend on or after commit `19fa9ba15`.

## Rollback Plan

Revert the commit. The change is type-only with no migrations or runtime behavior changes, so rolling back is safe and requires no data considerations. Consumers that have not yet started reading the new fields are unaffected.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR