### PR TITLE
feat: payout totals in affiliate paid volumes

### DIFF
--- a/src/affiliate-portal/types/index.ts
+++ b/src/affiliate-portal/types/index.ts
@@ -183,4 +183,10 @@ export interface GetAffiliatePaidVolumesByLevelResponse {
   payout_eligible_l3_attributions: number;
   /** Number of payout-eligible attribution events at L4. */
   payout_eligible_l4_attributions: number;
+  /** Sum of L1+L2+L3+L4 payout-eligible volume, in USD. */
+  payout_eligible_total_volume: number;
+  /** Sum of L1+L2+L3+L4 payout-eligible revenue, in USD. */
+  payout_eligible_total_revenue: number;
+  /** Sum of L1+L2+L3+L4 payout-eligible attribution counts. */
+  payout_eligible_total_attributions: number;
 }


### PR DESCRIPTION
## Description
Extends `GetAffiliatePaidVolumesByLevelResponse` in `src/affiliate-portal/types/index.ts` with three additive fields returned by the `GET /api/v1/affiliate-portal/paid-volumes-by-level` endpoint:

- `payout_eligible_total_volume: number` — sum of L1+L2+L3+L4 payout-eligible volume (USD).
- `payout_eligible_total_revenue: number` — sum of L1+L2+L3+L4 payout-eligible revenue (USD).
- `payout_eligible_total_attributions: number` — sum of L1+L2+L3+L4 payout-eligible attribution counts.

No runtime changes were needed in `AffiliatePortalService.getAffiliatePaidVolumesByLevel` or the `core.ts` re-export: the service forwards the raw response object from `HttpClient.get`, so the new fields flow through to consumers automatically once the type is updated.

## Why

The backend (`feat/totals-paid-volumes`, commit `f9ed99155`) added pre-computed cross-level aggregates in the presenter so consumers no longer need to sum the four per-level values client-side. Updating the SDK type unblocks TypeScript consumers from reading the totals without resorting to `as any` or local type augmentation. The change is purely additive and backward compatible — existing per-level fields and their types are unchanged.

## Test Plan

- [x] Tested locally
- [x] Tested in staging

- Run `npm run lint && npm run format` to confirm formatting/lint is clean.
- Run `npm run test` — existing `AffiliatePortalService.test.ts` cases for `getAffiliatePaidVolumesByLevel` should continue to pass; the contract change is type-only.
- Run `npm run build` and verify `dist/index.d.ts` includes the three new fields on `GetAffiliatePaidVolumesByLevelResponse`.
- In a TypeScript consumer, call `Fuul.getAffiliatePaidVolumesByLevel(...)` against a backend on `feat/totals-paid-volumes` (or later) and confirm `payout_eligible_total_volume`, `payout_eligible_total_revenue`, and `payout_eligible_total_attributions` are present and typed as `number`.

## Rollback Plan

Revert the single commit on this branch (or remove the three field declarations appended to `GetAffiliatePaidVolumesByLevelResponse` in `src/affiliate-portal/types/index.ts`). The change is type-only with no runtime, data, or migration impact — rollback is safe and requires no coordination with the backend, since the backend response simply contains extra properties that the older type ignores.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR