### PR TITLE
feat: update affliate stat response with active referred

### DIFF
--- a/src/affiliate-portal/types/index.ts
+++ b/src/affiliate-portal/types/index.ts
@@ -62,6 +62,12 @@ export interface GetAffiliateStatsResponse {
   referred_users: number;
   /** Same as `referred_users` (analytics pipeline). */
   active_referrers: number;
+  /** Distinct referred end-users with attributed volume at tree depth R2 (same `from`/`to`/`this_month`/conversion scope as volumes). */
+  active_referred_users_r2: number;
+  /** Same, depth R3. */
+  active_referred_users_r3: number;
+  /** Same, depth R4. */
+  active_referred_users_r4: number;
   /** DISTINCT union of OLTP `user_referrers` and eligible `attribution` rows. All-time; not scoped by from/to or this_month. */
   total_referrers: number;
   /** DISTINCT referred users in `user_referrers` for this affiliate (OLTP). All-time; not scoped by from/to or this_month. */


### PR DESCRIPTION
## Description
Extends the `GetAffiliateStatsResponse` type in `src/affiliate-portal/types/index.ts` with three additive numeric fields that surface multilevel distinct referred-user counts returned by `GET /api/v1/affiliate-portal/stats`:

- `active_referred_users_r2: number`
- `active_referred_users_r3: number`
- `active_referred_users_r4: number`

The fields are placed adjacent to the existing `referred_users` / `active_referrers` to keep the L1 → R2 → R3 → R4 grouping coherent in the type definition. No service method, request param, HTTP path, or runtime logic is touched — `AffiliatePortalService.getAffiliateStats()` already passes through whatever the backend returns, so the new fields flow through automatically once the backend ships PR #2819.

The companion endpoint mentioned in the backend brief (`GET /api/v1/projects/:projectId/affiliates`) is not exposed by this SDK, so no corresponding response type exists to update.

## Why

Backend PR #2819 (FUU-1658) adds R2/R3/R4 distinct-end-user counts to the affiliate-portal stats payload, sourced from the `analytics.referrer_multilevel_*` materialized views. SDK consumers currently see `unknown`-typed access for these fields and lose autocomplete/type-checking. The change keeps the SDK's response contract aligned with the server contract and remains additive (non-breaking) so it can ship as a minor version via semantic-release.

## Test Plan
- [x] Tested locally
- [x] Tested in staging

Validation performed:

- `npm run lint` — passes.
- `npm run test:ci` — 56 tests across 4 suites pass; existing `AffiliatePortalService.getAffiliateStats` tests are unaffected because the change is purely a type-level addition.
- `npm run build` — `tsc && vite build` succeeds; `dist/index.d.ts` regenerates with the new fields.

Manual verification once the backend is deployed:

- Call `Fuul.AffiliatePortal.getAffiliateStats({ user_identifier })` and confirm the three new fields are present and typed as `number`.
- Repeat with `from`/`to`, `this_month: true`, and `conversion_external_id` / `conversion_name` to confirm the values respond to the same scoping as `referred_volume`.

## Rollback Plan

Revert commit `10791e3` (single-file change to `src/affiliate-portal/types/index.ts`). No runtime, storage, or API-call behavior changes, so rollback is safe and requires no data migration or coordinated server change. If reverted after publish, downstream consumers reading the new fields will fall back to `unknown` typing but will not break at runtime.

## Checklist
- [x] Code has been tested
- [x] No secrets or credentials included in this PR