### PR TITLE
feat: add date filters on getPayoutsByReferrer

### DIFF
--- a/src/payouts/PayoutService.ts
+++ b/src/payouts/PayoutService.ts
@@ -69,6 +69,8 @@ export class PayoutService {
         user_identifier: params.user_identifier,
         user_identifier_type: params.user_identifier_type,
         referrer_scope: params.referrer_scope,
+        from_date: params.from_date,
+        to_date: params.to_date,
       },
     });
     return results.data;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -811,6 +811,10 @@ export interface GetPayoutsByReferrerParams {
   user_identifier_type: UserIdentifierType;
   /** `active` (default): only referred users with non-zero volume or earnings. `all`: also includes referred users present only in `user_referrers` (volume `0`, empty `earnings`, `date_joined: null`). */
   referrer_scope?: ReferrerPayoutsScope;
+  /** ISO 8601 date (`YYYY-MM-DD`). Must be provided together with `to_date`. When both are omitted, the endpoint returns all-time totals. `date_joined` is always all-time and not affected by this window. */
+  from_date?: string;
+  /** ISO 8601 date (`YYYY-MM-DD`). Inclusive upper bound. Must be provided together with `from_date`. */
+  to_date?: string;
 }
 
 // Referred Volume types


### PR DESCRIPTION
## Description
Extends `PayoutService.getPayoutsByReferrer` to forward two new optional query parameters (`from_date`, `to_date`) to `GET /api/v1/payouts/by-referrer`.

Changes:
- `src/types/api.ts` — `GetPayoutsByReferrerParams` gains `from_date?: string` and `to_date?: string` (ISO 8601 `YYYY-MM-DD`). JSDoc documents the pair-required rule and the `date_joined` all-time invariant (the API returns 400 if only one of the two is provided or if `from_date > to_date`).
- `src/payouts/PayoutService.ts` — Both fields are passed through in the request `queryParams`. No new validation or transformation layer; axios omits `undefined` params, so callers that pass neither preserve the existing all-time request shape.

No changes to response typings — `PayoutsByReferrerResponse` (`Array<Record<string, ReferrerPayoutData>>`) is unchanged across both the all-time and date-windowed paths.

## Why

The `/payouts/by-referrer` endpoint now supports optional date-range filtering for `volume` and `earnings`. The SDK must expose these parameters so consumers can request period-scoped results through the typed client instead of hand-building query strings.

Client-side pair/order validation was intentionally not added: the SDK follows a pass-through convention for query params elsewhere (e.g. `referrer_scope`), the API already returns a structured 400, and a coupled-pair validator would be the only such check in this service.

## Test Plan
- [x] Tested locally
- [x] Tested in staging

Manual verification:
- Call `Fuul.getPayoutsByReferrer({ user_identifier, user_identifier_type })` with no date params — response matches pre-PR all-time behavior; URL contains no `from_date`/`to_date`.
- Call with both `from_date` and `to_date` — request URL includes both params; response `volume`/`earnings` are windowed while `date_joined` stays at the all-time first attribution.
- Call with only `from_date` (or only `to_date`) — API returns 400; SDK surfaces the axios error to the caller (no client-side short-circuit, by design).
- Call with `from_date > to_date` — API returns 400; SDK surfaces the error.
- Call with a range that excludes all activity — response is `[]` (empty array), not an error.

Type check / build:
- `npm run lint && npm run format`
- `npm run test`
- `npm run build`

## Rollback Plan

Revert the two files (`src/types/api.ts`, `src/payouts/PayoutService.ts`). The change is purely additive on the request side and does not touch the singleton, HttpClient, or any other service. No data, persisted state, or wire-format implications. Existing consumers that never sent the new params are unaffected by either the change or its rollback.

## Checklist
- [x] Code has been tested
- [x] No secrets or credentials included in this PR