### PR TITLE
feat: add eligible volume + total commission to ReferrerPayoutData

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -794,7 +794,14 @@ export interface EarningItem {
 
 export interface ReferrerPayoutData {
   volume: number;
+  /** L1 trading volume from this referred user that is eligible for commission. */
+  direct_eligible_volume: number;
+  /** Eligible volume from this user's downline (L2-L4), mapped to this L1 user. */
+  indirect_eligible_volume: number;
+  /** L1-only commission, by currency. */
   earnings: EarningItem[];
+  /** Combined direct + indirect (L1-L4) commission, by currency. */
+  total_commission_earned: EarningItem[];
   /** `null` when the referred user has no confirmed attributions (only present in `user_referrers` — returned when `referrer_scope=all`). */
   date_joined: string | null;
   event_referrer_identifier: string;


### PR DESCRIPTION
## Description
<!-- What changes does this PR introduce? -->
Extends the `ReferrerPayoutData` interface in `src/types/api.ts` with four additional fields to model multi-level (L1–L4) eligible volume and commission in the payouts-by-referrer response.

New fields on `ReferrerPayoutData`:

- `direct_eligible_volume: number` — L1 trading volume from the referred user that is eligible for commission.
- `indirect_eligible_volume: number` — eligible volume from the referred user's downline (L2–L4), mapped onto this L1 user.
- `total_commission_earned: EarningItem[]` — combined direct + indirect (L1–L4) commission, expressed as a per-currency `EarningItem[]`, mirroring the existing `earnings` shape.

The pre-existing `earnings: EarningItem[]` field is now documented as L1-only commission, distinguishing it from the new aggregated `total_commission_earned`. Each field carries an inline JSDoc comment so consumers can disambiguate direct vs. indirect and L1-only vs. full-chain values.

This is a type-only, purely additive change. It affects the structural contract returned by the payouts-by-referrer query (`PayoutsByReferrerResponse` → `Record<string, ReferrerPayoutData>`); no runtime logic, service methods, or request shapes were modified.

## Why

<!-- Why are these changes necessary or beneficial? -->

The previous `ReferrerPayoutData` shape only exposed total `volume` and L1-only `earnings`, with no way for consumers to distinguish commission-eligible volume from raw volume, or to separate direct (L1) earnings from downline (L2–L4) earnings. The API now returns the eligible-volume and full-chain commission breakdown; the SDK types must reflect that contract so consumers get accurate type information and can render per-level commission without inferring or recomputing values client-side.

The fields are added (not replaced) to preserve backward compatibility for existing consumers reading `volume` and `earnings`.

## Test Plan

<!-- How was this tested? Include steps to verify the changes work correctly. -->

- Run the validation loop:
  - `npm run lint && npm run format`
  - `npm run test`
  - `npm run build` (verify `dist/index.d.ts` includes the new `ReferrerPayoutData` fields)
- Confirm a consumer can read `direct_eligible_volume`, `indirect_eligible_volume`, and `total_commission_earned` off the payouts-by-referrer response without type errors.
- Confirm existing consumers reading only `volume` / `earnings` still type-check (additive change, no breakage).

- [x] Tested locally
- [x] Tested in staging

## Rollback Plan

<!-- How can this change be reverted if something goes wrong? -->

Revert the single commit touching `src/types/api.ts`. The change is type-only and additive — reverting removes the four field declarations with no runtime or data implications. No feature flags, migrations, or data considerations are involved. Consumers that began reading the new fields would need to drop those references, but no stored data is affected.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR