### PR TITLE
[FUU-1796] ci: GitHub App token for release push

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -16,10 +16,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch tags
         run: git fetch --tags --force
@@ -42,5 +50,5 @@ jobs:
       - name: Release
         if: github.event_name == 'push'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: npx semantic-release


### PR DESCRIPTION
Linear: https://linear.app/fuul/issue/FUU-1796

## Description
Switch the release job from the default GITHUB_TOKEN (github-actions[bot]) to a GitHub App token (Fuul Release Bot) for the @semantic-release/git push to main.

## Why
main is now protected by the org ruleset "Main branch protection" (PR + 1 review, no force-push, signed commits). semantic-release pushes the chore(release) commit directly to main, which the ruleset blocks for github-actions[bot]. The Fuul Release Bot App is in the ruleset bypass list (Always), so releases authenticated as the App can push while humans still go through PRs.

## Test Plan
- Merge this PR (merge commit, keep the conventional ci: message so semantic-release does not cut a release for it).
- On the next release-triggering merge to main, confirm the Build and Release workflow mints an App token and the chore(release) commit is pushed to main by Fuul Release Bot (not blocked by the ruleset).

## Rollback Plan
Revert this commit to restore the previous workflow using secrets.GITHUB_TOKEN. Note: with the ruleset active, reverting re-breaks release pushes until the App token is restored.

## Checklist
- [x] Repo secrets RELEASE_APP_ID + RELEASE_APP_PRIVATE_KEY set
- [x] Fuul Release Bot App installed on this repo
- [x] App added to ruleset bypass list (Always)