### PR TITLE
fix: simplify detectSource to a single nullish return

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -32,8 +32,5 @@ export const getQueryParam = (key: string) => {
 };
 
 export const detectSource = (): string | undefined => {
-  const sourceParam = getQueryParam('source');
-  if (sourceParam) {
-    return sourceParam;
-  }
+  return getQueryParam('source') || undefined;
 };


### PR DESCRIPTION
## What

Collapse the redundant `if`-block in `detectSource()` into a single `getQueryParam('source') || undefined` return.

## Why

- Behavior-preserving: empty-string params (`?source=`) still map to `undefined` (kept `||`, not `??`, to preserve the falsy check).
- Aligns the returned value with the declared `string | undefined` return type.
- Doubles as a patch-release smoke test for the `versioning.yml` workflow.

## Release impact

`fix:` commit → semantic-release will cut a **patch bump (7.40.0 → 7.40.1)** and publish `@fuul/sdk@7.40.1` **once this is merged into `main`** (the release step only runs on push to main, not on the PR).

## Verification

- `npm run lint` — clean
- `npm run build` — green (UMD + ESM)
- `npm run test:ci` — 56/56 passing