### PR TITLE
[FUU-1899] surface API error message from response body

### DIFF
--- a/src/referral-codes/ReferralCodeService.test.ts
+++ b/src/referral-codes/ReferralCodeService.test.ts
@@ -1,0 +1,82 @@
+import { AxiosError } from 'axios';
+
+import { ValidationError } from '../affiliates/errors';
+import { HttpClient } from '../HttpClient';
+import { UserIdentifierType } from '../types/user';
+import { ReferralCodeService } from './ReferralCodeService';
+
+describe('ReferralCodeService', () => {
+  describe('useReferralCode', () => {
+    const baseParams = {
+      code: 'ABC123',
+      user_identifier: '0x123',
+      user_identifier_type: UserIdentifierType.EvmAddress,
+      signature: 'signature',
+      signature_message: 'message',
+    };
+
+    it('returns data on a successful response', async () => {
+      const httpClientMock = {
+        patch: jest.fn().mockResolvedValue({ data: undefined }),
+      };
+      const service = new ReferralCodeService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      await expect(service.useReferralCode(baseParams)).resolves.toBeUndefined();
+      expect(httpClientMock.patch).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws the real API message instead of the generic Axios message on a 422', async () => {
+      const axiosError = new AxiosError('Request failed with status code 422', 'ERR_BAD_REQUEST', undefined, undefined, {
+        status: 422,
+        data: { message: 'User already has a referrer', statusCode: 422 },
+      } as any);
+
+      const httpClientMock = {
+        patch: jest.fn().mockRejectedValue(axiosError),
+      };
+      const service = new ReferralCodeService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      await expect(service.useReferralCode(baseParams)).rejects.toThrow('User already has a referrer');
+    });
+
+    it('throws a ValidationError when the API returns an array of messages', async () => {
+      const axiosError = new AxiosError('Request failed with status code 422', 'ERR_BAD_REQUEST', undefined, undefined, {
+        status: 422,
+        data: { message: ['user_identifier must be a valid address', 'signature is required'], statusCode: 422 },
+      } as any);
+
+      const httpClientMock = {
+        patch: jest.fn().mockRejectedValue(axiosError),
+      };
+      const service = new ReferralCodeService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      await expect(service.useReferralCode(baseParams)).rejects.toBeInstanceOf(ValidationError);
+      await expect(service.useReferralCode(baseParams)).rejects.toThrow('user_identifier must be a valid address, signature is required');
+    });
+
+    it('rethrows the original error when it is not an AxiosError', async () => {
+      const originalError = new Error('network down');
+
+      const httpClientMock = {
+        patch: jest.fn().mockRejectedValue(originalError),
+      };
+      const service = new ReferralCodeService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      await expect(service.useReferralCode(baseParams)).rejects.toBe(originalError);
+    });
+
+    it('rethrows the original AxiosError when the response has no message', async () => {
+      const axiosError = new AxiosError('Request failed with status code 500', 'ERR_BAD_RESPONSE', undefined, undefined, {
+        status: 500,
+        data: {},
+      } as any);
+
+      const httpClientMock = {
+        patch: jest.fn().mockRejectedValue(axiosError),
+      };
+      const service = new ReferralCodeService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      await expect(service.useReferralCode(baseParams)).rejects.toBe(axiosError);
+    });
+  });
+});

--- a/src/referral-codes/ReferralCodeService.ts
+++ b/src/referral-codes/ReferralCodeService.ts
@@ -1,3 +1,6 @@
+import { AxiosError } from 'axios';
+
+import { ValidationError } from '../affiliates/errors';
 import { HttpClient } from '../HttpClient';
 import {
   DeleteReferralParams,
@@ -28,95 +31,135 @@ export class ReferralCodeService {
   }
 
   public async listUserReferralCodes(params: ListUserReferralCodesParams): Promise<ListUserReferralCodesResponse> {
-    const response = await this.httpClient.get<ListUserReferralCodesResponse>({
-      path: `/referral_codes`,
-      queryParams: {
-        user_identifier: params.user_identifier,
-        user_identifier_type: params.user_identifier_type,
-        page: params.page,
-        page_size: params.page_size,
-      },
-    });
-    return response.data;
+    try {
+      const response = await this.httpClient.get<ListUserReferralCodesResponse>({
+        path: `/referral_codes`,
+        queryParams: {
+          user_identifier: params.user_identifier,
+          user_identifier_type: params.user_identifier_type,
+          page: params.page,
+          page_size: params.page_size,
+        },
+      });
+      return response.data;
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async generateReferralCodes(params: GenerateReferralCodesParams): Promise<GenerateReferralCodesResponse[]> {
-    const response = await this.httpClient.post<GenerateReferralCodesResponse[]>({
-      path: `/referral_codes`,
-      queryParams: {
-        user_identifier: params.user_identifier,
-        user_identifier_type: params.user_identifier_type,
-        quantity: params.quantity,
-        max_uses: params.max_uses,
-      },
-    });
+    try {
+      const response = await this.httpClient.post<GenerateReferralCodesResponse[]>({
+        path: `/referral_codes`,
+        queryParams: {
+          user_identifier: params.user_identifier,
+          user_identifier_type: params.user_identifier_type,
+          quantity: params.quantity,
+          max_uses: params.max_uses,
+        },
+      });
 
-    return response.data;
+      return response.data;
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async getReferralStatus(params: GetReferralStatusParams): Promise<GetReferralStatusResponse> {
-    const response = await this.httpClient.get<GetReferralStatusResponse>({
-      path: `/referral_codes/status`,
-      queryParams: {
-        user_identifier: params.user_identifier,
-        user_identifier_type: params.user_identifier_type,
-      },
-    });
+    try {
+      const response = await this.httpClient.get<GetReferralStatusResponse>({
+        path: `/referral_codes/status`,
+        queryParams: {
+          user_identifier: params.user_identifier,
+          user_identifier_type: params.user_identifier_type,
+        },
+      });
 
-    return response.data;
+      return response.data;
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async getReferralCode(params: GetReferralCodeParams): Promise<GetReferralCodeResponse> {
-    const response = await this.httpClient.get<GetReferralCodeResponse>({
-      path: `/referral_codes/${params.code}`,
-    });
+    try {
+      const response = await this.httpClient.get<GetReferralCodeResponse>({
+        path: `/referral_codes/${params.code}`,
+      });
 
-    return response.data;
+      return response.data;
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async useReferralCode(params: UseReferralCodeParams): Promise<void> {
     const { code, user_identifier, user_identifier_type, signature, signature_message, chain_id } = params;
 
-    await this.httpClient.patch<void>({
-      path: `/referral_codes/${code}/use`,
-      queryParams: {
-        user_identifier,
-        user_identifier_type,
-      },
-      postData: {
-        signature,
-        signature_message,
-        chain_id,
-      },
-    });
+    try {
+      await this.httpClient.patch<void>({
+        path: `/referral_codes/${code}/use`,
+        queryParams: {
+          user_identifier,
+          user_identifier_type,
+        },
+        postData: {
+          signature,
+          signature_message,
+          chain_id,
+        },
+      });
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async updateReferralCode(params: UpdateReferralCodeParams): Promise<void> {
-    await this.httpClient.patch<void>({
-      path: `/referral_codes/${params.code}`,
-      postData: {
-        max_uses: params.max_uses,
-      },
-    });
+    try {
+      await this.httpClient.patch<void>({
+        path: `/referral_codes/${params.code}`,
+        postData: {
+          max_uses: params.max_uses,
+        },
+      });
+    } catch (e) {
+      this.handleError(e);
+    }
   }
 
   public async deleteReferral(params: DeleteReferralParams): Promise<void> {
     const { code, user_identifier, user_identifier_type, referrer_identifier, referrer_identifier_type, signature, signature_message, chain_id } =
       params;
 
-    await this.httpClient.delete<void>({
-      path: `/referral_codes/${code}/referrals`,
-      queryParams: {
-        user_identifier,
-        user_identifier_type,
-        referrer_identifier,
-        referrer_identifier_type,
-      },
-      postData: {
-        signature,
-        signature_message,
-        chain_id,
-      },
-    });
+    try {
+      await this.httpClient.delete<void>({
+        path: `/referral_codes/${code}/referrals`,
+        queryParams: {
+          user_identifier,
+          user_identifier_type,
+          referrer_identifier,
+          referrer_identifier_type,
+        },
+        postData: {
+          signature,
+          signature_message,
+          chain_id,
+        },
+      });
+    } catch (e) {
+      this.handleError(e);
+    }
+  }
+
+  private handleError(e: unknown): never {
+    if (e instanceof AxiosError) {
+      const data = e.response?.data;
+      if (typeof data?.message === 'string') {
+        throw new Error(data.message);
+      } else if (data?.message instanceof Array) {
+        throw new ValidationError(data.message);
+      }
+    }
+    throw e;
   }
 }


### PR DESCRIPTION
## Description

Referral-code methods in the SDK now surface the real API error message from the 422 response body instead of letting Axios's generic `"Request failed with status code 422"` propagate.

How it works:

- Added a shared private `handleError` helper in `ReferralCodeService`, following the existing `AffiliateService` convention:
  - `AxiosError` with a string `response.data.message` → `throw new Error(message)` (real reason, exact casing)
  - array-shaped `message` → `ValidationError` (joined messages)
  - anything else → rethrow unchanged
- Wrapped the service methods to route errors through it.
- Backwards-compatible: no method signature or return-type changes. The only behavior change is that thrown `Error.message` now carries the real API reason.

## Why

When a referral confirmation fails (e.g. the user is already linked to another referrer), the API already returns the specific reason in the 422 body (e.g. `{ "message": "User already has a referrer", "statusCode": 422 }`). But `ReferralCodeService` had no error handling, so consumers only saw Axios's generic status-code string — which reads as a broken link and drives support tickets. The reason was already known server-side; the SDK just wasn't surfacing it.

## Test Plan

- New colocated suite `src/referral-codes/ReferralCodeService.test.ts`: success passthrough, real 422 message surfaced (not the generic Axios string), array → `ValidationError`, non-Axios error rethrown unchanged.
- Full suite: 66/66 passing. Lint + build clean.

- [x] Tested locally
- [ ] Tested in staging

## Rollback Plan

Revert this PR. The change is isolated to `ReferralCodeService` error handling and its colocated test; no schema, signature, or return-type changes, so reverting restores the previous generic-error behavior with no migration needed.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR

## Context

Slack thread: https://fuul.slack.com/archives/C08U0V365AB/p1783696787468289?thread_ts=1783689255.748709&cid=C08U0V365AB

---
_Generated by [Claude Code](https://claude.ai/code/session_019CodRmzpi8tQxw879CjMe5)_