### PR TITLE
feat: add stellar_address user identifier type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,11 @@ EventService uses localStorage (`SENT_EVENT_ID_KEY`) with 60-second validity per
 ### Multi-Project Support
 Events can be sent to multiple projects: `sendEvent(event, ['projectId1', 'projectId2'])` — sends one HTTP call per project.
 
+### Multi-Chain Support
+`UserIdentifierType` enum values: `evm_address`, `solana_address`, `xrpl_address`, `sui_address`, `stellar_address`, `email`.
+
 ### Signature Verification
-Affiliate operations require EIP-191 signatures. Smart contract signatures supported via EIP-1271 with `accountChainId` parameter.
+Affiliate operations require EIP-191 signatures (EVM). Smart contract signatures supported via EIP-1271 (EVM) with `accountChainId` parameter. Non-EVM identifiers use their chain's native scheme (Stellar → ed25519, no `accountChainId`); the SDK forwards signature bytes untouched without validation.
 
 ## Testing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,13 +84,15 @@ constructor(settings: { httpClient: HttpClient; debug?: boolean })
 
 ### Multi-Chain Support
 
-`UserIdentifierType` enum values: `evm_address`, `solana_address`, `xrpl_address`, `sui_address`, `email`.
+`UserIdentifierType` enum values: `evm_address`, `solana_address`, `xrpl_address`, `sui_address`, `stellar_address`, `email`.
 
 ### Signature Verification
 
 Affiliate code creation and referral code usage require message signatures:
-- EIP-191 standard signatures
-- EIP-1271 smart contract signatures (requires `accountChainId` parameter)
+- EIP-191 standard signatures (EVM)
+- EIP-1271 smart contract signatures (EVM, requires `accountChainId` parameter)
+
+Non-EVM identifiers authenticate with their chain's native scheme (e.g. Stellar `G…` addresses sign with ed25519 — a StrKey-encoded ed25519 public key — and take no `accountChainId`). The SDK is a pure pass-through: it forwards `signature` / `signaturePublicKey` / `accountChainId` untouched and performs no scheme validation, so any scheme works at runtime.
 
 ### Key Types
 

--- a/src/types/user.test.ts
+++ b/src/types/user.test.ts
@@ -1,0 +1,7 @@
+import { UserIdentifierType } from './user';
+
+describe('UserIdentifierType', () => {
+  it('maps StellarAddress to stellar_address', () => {
+    expect(UserIdentifierType.StellarAddress).toBe('stellar_address');
+  });
+});

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -3,5 +3,6 @@ export enum UserIdentifierType {
   SolanaAddress = 'solana_address',
   XRPLAddress = 'xrpl_address',
   SuiAddress = 'sui_address',
+  StellarAddress = 'stellar_address',
   Email = 'email',
 }


### PR DESCRIPTION
## Description

Adds `StellarAddress = 'stellar_address'` to the `UserIdentifierType` enum, exposing Stellar as a supported user identifier type from `@fuul/sdk`. Also amends `CLAUDE.md` / `AGENTS.md` so the docs stop describing signatures as EVM-only (non-EVM identifiers authenticate with their chain's native scheme — Stellar `G…` addresses sign with ed25519 and take no `accountChainId`), and adds a colocated regression test.

This is a **type-only** change. The SDK is a pure pass-through API client — no crypto, no address validation/normalization, it never signs — so nothing chain-specific is implemented. `UserIdentifierType` is already re-exported from the package entry, so the new member is exported automatically (ESM, UMD, and `.d.ts`).

## Why

Both Fuul webapps import `UserIdentifierType` from `@fuul/sdk`. Publishing the new member SDK-first lets the frontends type against `UserIdentifierType.StellarAddress` instead of widening with string literals (the drift they already carry for `sui_address` / `xrpl_address`).

## Test Plan

- [x] Tested locally
- [ ] Tested in staging

Local validation loop (all green):
- `npm run lint` — clean
- `npm run format` — clean (no committed files reformatted)
- `npm run test:ci` — 67/67 tests pass, including the new `src/types/user.test.ts` assertion
- `npm run build` — dual-format build succeeds; both `dist/index.mjs` and `dist/index.umd.js` contain `stellar_address`
- Runtime: `node -e "…UserIdentifierType.StellarAddress"` → `stellar_address`

## Rollback Plan

Revert this PR. The change is type-only with no runtime behavior change, no data/schema migration, and no config — reverting fully removes the enum member.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR
