### PR TITLE
Claim check id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules/
 .git
 dist/
 coverage/
+agents/plans

--- a/src/claim-checks/types/index.ts
+++ b/src/claim-checks/types/index.ts
@@ -48,6 +48,11 @@ export enum ClaimCheckReason {
 }
 
 export interface ClaimResponse {
+  /**
+   * Unique identifier of the claim check (UUID)
+   */
+  id: string;
+
   project_address: string;
 
   /**

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -517,6 +517,7 @@ describe('SDK core', () => {
     it('should return claimable checks', async () => {
       const getClaimableChecksSpy = jest.spyOn(ClaimCheckService.prototype, 'getClaimableChecks').mockResolvedValue([
         {
+          id: '11111111-1111-1111-1111-111111111111',
           project_address: '0xproject',
           to: '0x123',
           currency: '0xtoken',
@@ -542,6 +543,7 @@ describe('SDK core', () => {
 
       expect(checks).toEqual([
         {
+          id: '11111111-1111-1111-1111-111111111111',
           project_address: '0xproject',
           to: '0x123',
           currency: '0xtoken',
@@ -570,6 +572,7 @@ describe('SDK core', () => {
     it('should work with email identifier', async () => {
       jest.spyOn(ClaimCheckService.prototype, 'getClaimableChecks').mockResolvedValue([
         {
+          id: '22222222-2222-2222-2222-222222222222',
           project_address: '0xproject',
           to: 'user@example.com',
           currency: '0xtoken',
@@ -915,6 +918,7 @@ describe('SDK core', () => {
     it('should close claim checks and return signed responses', async () => {
       const closeClaimChecksSpy = jest.spyOn(ClaimCheckService.prototype, 'closeClaimChecks').mockResolvedValue([
         {
+          id: '33333333-3333-3333-3333-333333333333',
           project_address: '0xproject',
           to: '0x123',
           currency: '0xtoken',


### PR DESCRIPTION
## Description

Adds the new `id` (UUID) field to the `ClaimResponse` type. The `POST /v1/claim-checks/claim` (`generateClaimSignature`) endpoint now returns a unique identifier for each claim check, and this exposes it to SDK consumers.

Because both `getClaimableChecks()` and `closeClaimChecks()` return `ClaimResponse[]`, callers of either method can now read `claim.id`. The field is typed as required, matching the other fields on `ClaimResponse` and the fact that the server always returns it.

## Why

The API was updated to include a per-claim-check `id`. Without it on the SDK type, TypeScript consumers can't access the identifier that the response already carries — needed to correlate, deduplicate, or reference individual claim checks.

## Test Plan

- [x] Tested locally
- [ ] Tested in staging

Updated the claim-check unit tests to include the new field; `getClaimableChecks`/`closeClaimChecks` suites and lint pass.

## Rollback Plan

Additive, type-only change with no runtime behavior. Revert this commit to remove the field.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR
