### PR TITLE
feat: add stellar_contract user identifier type

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,7 +84,9 @@ constructor(settings: { httpClient: HttpClient; debug?: boolean })
 
 ### Multi-Chain Support
 
-`UserIdentifierType` enum values: `evm_address`, `solana_address`, `xrpl_address`, `sui_address`, `stellar_address`, `email`.
+`UserIdentifierType` enum values: `evm_address`, `solana_address`, `xrpl_address`, `sui_address`, `stellar_address`, `stellar_contract`, `email`.
+
+`stellar_contract` (Soroban SAC / SEP-41 `C…` StrKey) is scoped to currencies on the API side — user-identifier endpoints validate against wallet/opaque types and reject it. It is exported for completeness with the backend enum, not as a valid user identifier.
 
 ### Signature Verification
 

--- a/src/types/user.test.ts
+++ b/src/types/user.test.ts
@@ -4,4 +4,8 @@ describe('UserIdentifierType', () => {
   it('maps StellarAddress to stellar_address', () => {
     expect(UserIdentifierType.StellarAddress).toBe('stellar_address');
   });
+
+  it('maps StellarContract to stellar_contract', () => {
+    expect(UserIdentifierType.StellarContract).toBe('stellar_contract');
+  });
 });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -4,5 +4,12 @@ export enum UserIdentifierType {
   XRPLAddress = 'xrpl_address',
   SuiAddress = 'sui_address',
   StellarAddress = 'stellar_address',
+  /**
+   * Stellar contract (Soroban SAC / SEP-41) address — a `C…` StrKey.
+   *
+   * Note: the API scopes this type to currencies. User-identifier endpoints
+   * validate against wallet/opaque types and will reject it.
+   */
+  StellarContract = 'stellar_contract',
   Email = 'email',
 }


### PR DESCRIPTION
## Description

Adds `stellar_contract` to the `UserIdentifierType` enum, bringing the SDK in line with the backend's `IdentifierType`.

The new member is documented inline: `stellar_contract` is a Soroban SAC / SEP-41 contract address (a `C…` StrKey), and the API scopes it to **currencies only**. User-identifier endpoints validate against wallet and opaque types and will reject it, so the doc comment marks it as exported for enum parity rather than as a usable user identifier. The same caveat is mirrored in the Multi-Chain Support section of `CLAUDE.md` so the constraint isn't lost.

Covered by a unit test asserting the string mapping, matching the existing `stellar_address` case.

Change is purely additive — no existing enum values, request shapes, or runtime behavior are touched. The `feat:` commit type bumps the SDK a minor version (7.44.0 → 7.45.0).

## Why

The backend added `stellar_contract` to its `IdentifierType` enum to support Stellar currencies (`AddStellarContractIdentifierType` migration, plus `StellarContractIdentifier` in `shared/identifier`). The SDK enum had drifted from it, leaving consumers without a typed constant for the value.

Worth flagging for reviewers: because the backend deliberately keeps `stellar_contract` off user-identifier paths — `Identifier.fromCurrencyString` resolves it separately precisely so it doesn't leak into `getIdentifierType` — this export widens the SDK's user-identifier type beyond what those endpoints accept. That tradeoff was made intentionally in favor of enum parity; the doc comment is what keeps callers from misusing it.

## Test Plan

- [ ] Tested locally
- [ ] Tested in staging

## Rollback Plan

Revert the commit and release a patch. Nothing depends on the new member and no existing value changed, so removing it only affects code that explicitly references `UserIdentifierType.StellarContract` — a compile-time break, not a runtime one.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR
