### PR TITLE
[FUU-1902] feat: add reason filter to getClaimCheckTotals

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,4 +129,22 @@ totals.unclaimed
 
 An optional `status` filter of type `ClaimCheckTotalsStatusFilter` limits the response to a single state — for example `status: ClaimCheckTotalsStatusFilter.Closed` returns only the ready-to-claim rows. `ClaimCheckTotalsStatusFilter.Unclaimed` filters to the umbrella (both `open` and `closed` rows). The enum members map to the wire values `'claimed' | 'unclaimed' | 'open' | 'closed'`; invalid values return a `400` listing the valid ones.
 
+An optional `reason` filter of type `ClaimCheckTotalsReasonFilter` narrows which rows are summed by earning type: `AffiliatePayout` is commission earned for referring others, `EndUserPayout` is the rebate a user earned on their own activity, `AgencyPayout` is an agency's share. When omitted, all earning types are merged into one figure per currency and state.
+
+The filter does not change the response shape — rows carry no `reason` field — so showing commission and rebates as separate figures means calling twice:
+
+```tsx
+import { ClaimCheckTotalsReasonFilter, Fuul, UserIdentifierType } from '@fuul/sdk';
+
+const ids = {
+  user_identifier: '0xe06099DbbF626892397f9A74C7f42F16748292Db',
+  user_identifier_type: UserIdentifierType.EvmAddress
+};
+
+const commission = await Fuul.getClaimCheckTotals({ ...ids, reason: ClaimCheckTotalsReasonFilter.AffiliatePayout });
+const rebates = await Fuul.getClaimCheckTotals({ ...ids, reason: ClaimCheckTotalsReasonFilter.EndUserPayout });
+```
+
+`reason` combines with `status` — pass both to get, for example, only the ready-to-claim rebate rows.
+
 Expired checks are excluded from `open` and `closed` rows, so `closed` sums are always claimable right now. Claimed totals are the user's claim history.

--- a/src/claim-checks/ClaimCheckService.test.ts
+++ b/src/claim-checks/ClaimCheckService.test.ts
@@ -1,0 +1,66 @@
+import { HttpClient } from '../HttpClient';
+import { UserIdentifierType } from '../types/user';
+import { ClaimCheckService } from './ClaimCheckService';
+import { ClaimCheckTotalsReasonFilter, ClaimCheckTotalsStatusFilter } from './types';
+
+describe('ClaimCheckService', () => {
+  describe('getClaimCheckTotals', () => {
+    const baseParams = {
+      user_identifier: '0x123',
+      user_identifier_type: UserIdentifierType.EvmAddress,
+    };
+
+    const buildService = () => {
+      const httpClientMock = {
+        get: jest.fn().mockResolvedValue({ data: { claimed: [], unclaimed: [] } }),
+      };
+      const service = new ClaimCheckService({ httpClient: httpClientMock as unknown as HttpClient });
+
+      return { httpClientMock, service };
+    };
+
+    it('forwards the reason filter as a query param', async () => {
+      const { httpClientMock, service } = buildService();
+
+      await service.getClaimCheckTotals({ ...baseParams, reason: ClaimCheckTotalsReasonFilter.EndUserPayout });
+
+      expect(httpClientMock.get).toHaveBeenCalledWith({
+        path: '/claim-checks/totals',
+        queryParams: {
+          user_identifier: '0x123',
+          user_identifier_type: UserIdentifierType.EvmAddress,
+          reason: 'end_user_payout',
+        },
+      });
+    });
+
+    it('omits reason entirely when not supplied', async () => {
+      const { httpClientMock, service } = buildService();
+
+      await service.getClaimCheckTotals(baseParams);
+
+      const { queryParams } = httpClientMock.get.mock.calls[0][0];
+      expect(Object.keys(queryParams)).not.toContain('reason');
+    });
+
+    it('forwards status and reason together', async () => {
+      const { httpClientMock, service } = buildService();
+
+      await service.getClaimCheckTotals({
+        ...baseParams,
+        status: ClaimCheckTotalsStatusFilter.Closed,
+        reason: ClaimCheckTotalsReasonFilter.AffiliatePayout,
+      });
+
+      expect(httpClientMock.get).toHaveBeenCalledWith({
+        path: '/claim-checks/totals',
+        queryParams: {
+          user_identifier: '0x123',
+          user_identifier_type: UserIdentifierType.EvmAddress,
+          status: 'closed',
+          reason: 'affiliate_payout',
+        },
+      });
+    });
+  });
+});

--- a/src/claim-checks/ClaimCheckService.ts
+++ b/src/claim-checks/ClaimCheckService.ts
@@ -97,7 +97,11 @@ export class ClaimCheckService {
    * `status: 'closed'` (ready to claim on-chain). Expired checks are excluded
    * from open/closed rows. Claimed checks are past claims (`status: 'claimed'`).
    *
-   * @param {GetClaimCheckTotalsParams} params - User identifier and optional status filter
+   * The optional `reason` filter narrows which rows are summed by earning type
+   * without changing the response shape. When omitted, all earning types are
+   * merged into one figure per currency and state.
+   *
+   * @param {GetClaimCheckTotalsParams} params - User identifier and optional status and reason filters
    * @returns {Promise<GetClaimCheckTotalsResponse>} Totals grouped by status and currency
    */
   public async getClaimCheckTotals(params: GetClaimCheckTotalsParams): Promise<GetClaimCheckTotalsResponse> {
@@ -108,6 +112,10 @@ export class ClaimCheckService {
 
     if (params.status) {
       queryParams.status = params.status;
+    }
+
+    if (params.reason) {
+      queryParams.reason = params.reason;
     }
 
     const response = await this.httpClient.get<GetClaimCheckTotalsResponse>({

--- a/src/claim-checks/types/index.ts
+++ b/src/claim-checks/types/index.ts
@@ -105,6 +105,16 @@ export enum ClaimCheckTotalsStatusFilter {
   Closed = 'closed',
 }
 
+/**
+ * Earning type filter for claim check totals. Distinct from `ClaimCheckReason`,
+ * which is the numeric on-chain reason carried on `ClaimResponse`.
+ */
+export enum ClaimCheckTotalsReasonFilter {
+  AffiliatePayout = 'affiliate_payout',
+  EndUserPayout = 'end_user_payout',
+  AgencyPayout = 'agency_payout',
+}
+
 export interface GetClaimCheckTotalsParams {
   user_identifier: string;
   user_identifier_type: UserIdentifierType;
@@ -115,6 +125,17 @@ export interface GetClaimCheckTotalsParams {
    * and `closed` rows with `claimed` empty. When omitted, all states are returned.
    */
   status?: ClaimCheckTotalsStatusFilter;
+
+  /**
+   * Filter totals to a single earning type: `affiliate_payout` is commission earned
+   * for referring others, `end_user_payout` is the rebate a user earned on their own
+   * activity, `agency_payout` is an agency's share. When omitted, all types are summed
+   * into one figure per currency and state.
+   *
+   * This narrows which rows are summed — it does not change the response shape, and
+   * rows carry no `reason` field. To show commission and rebate separately, call twice.
+   */
+  reason?: ClaimCheckTotalsReasonFilter;
 }
 
 /**

--- a/src/core.test.ts
+++ b/src/core.test.ts
@@ -17,7 +17,7 @@ jest.mock('nanoid', () => ({
   nanoid: () => '123',
 }));
 
-import { ClaimCheckTotalsStatusFilter, Fuul, UserIdentifierType } from './index';
+import { ClaimCheckTotalsReasonFilter, ClaimCheckTotalsStatusFilter, Fuul, UserIdentifierType } from './index';
 import { LeaderboardService } from './leaderboard/LeaderboardService';
 import { PayoutService } from './payouts/PayoutService';
 
@@ -700,6 +700,25 @@ describe('SDK core', () => {
         user_identifier: '0x123',
         user_identifier_type: UserIdentifierType.EvmAddress,
         status: ClaimCheckTotalsStatusFilter.Closed,
+      });
+    });
+
+    it('should pass the reason filter through to the service', async () => {
+      const getClaimCheckTotalsSpy = jest.spyOn(ClaimCheckService.prototype, 'getClaimCheckTotals').mockResolvedValue({
+        claimed: [],
+        unclaimed: [],
+      });
+
+      await Fuul.getClaimCheckTotals({
+        user_identifier: '0x123',
+        user_identifier_type: UserIdentifierType.EvmAddress,
+        reason: ClaimCheckTotalsReasonFilter.EndUserPayout,
+      });
+
+      expect(getClaimCheckTotalsSpy).toHaveBeenCalledWith({
+        user_identifier: '0x123',
+        user_identifier_type: UserIdentifierType.EvmAddress,
+        reason: ClaimCheckTotalsReasonFilter.EndUserPayout,
       });
     });
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -1073,6 +1073,11 @@ export async function getClaimableChecks(params: GetClaimableChecksParams): Prom
  * `ClaimCheckTotalsStatusFilter.Unclaimed` means the umbrella (open + closed). The
  * members map to the wire values `'claimed' | 'unclaimed' | 'open' | 'closed'`;
  * invalid values return a 400.
+ *
+ * The optional `reason` filter takes a `ClaimCheckTotalsReasonFilter` member and
+ * narrows which rows are summed by earning type. It does not change the response
+ * shape — rows carry no `reason` field — so showing commission and rebate
+ * separately means calling twice. When omitted, all earning types are merged.
  * @param {GetClaimCheckTotalsParams} params Get claim check totals parameters
  * @returns {Promise<GetClaimCheckTotalsResponse>} Claim check totals grouped by status and currency
  * @example
@@ -1087,6 +1092,11 @@ export async function getClaimableChecks(params: GetClaimableChecksParams): Prom
  * readyToClaim.forEach(item => {
  *   console.log(`${item.currency_name}: ${item.amount} (${item.currency_address})`);
  * });
+ *
+ * // Commission earned for referring others, and rebates earned on own activity
+ * const ids = { user_identifier: '0x12345', user_identifier_type: UserIdentifierType.EvmAddress };
+ * const commission = await Fuul.getClaimCheckTotals({ ...ids, reason: ClaimCheckTotalsReasonFilter.AffiliatePayout });
+ * const rebate = await Fuul.getClaimCheckTotals({ ...ids, reason: ClaimCheckTotalsReasonFilter.EndUserPayout });
  * ```
  */
 export async function getClaimCheckTotals(params: GetClaimCheckTotalsParams): Promise<GetClaimCheckTotalsResponse> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export type {
   GetClaimHistoryResponse,
   UserClaimHistoryItem,
 } from './claim-checks/types';
-export { ClaimCheckStatus, ClaimCheckTotalsStatusFilter } from './claim-checks/types';
+export { ClaimCheckStatus, ClaimCheckTotalsReasonFilter, ClaimCheckTotalsStatusFilter } from './claim-checks/types';
 export type {
   Affiliate,
   AffiliateCodeWithStats,


### PR DESCRIPTION
## Description

Adds an optional `reason` filter to `getClaimCheckTotals`, narrowing which rows are summed by earning type. It takes a new `ClaimCheckTotalsReasonFilter` string enum — `affiliate_payout`, `end_user_payout`, `agency_payout` — matching the server's enum exactly.

The response shape is unchanged: rows carry no `reason` field and cardinality is the same, so separating commission from rebates means calling twice. When `reason` is omitted, behavior is identical to today's merged figure.

`ClaimCheckTotalsReasonFilter` is deliberately a **new** type rather than a reuse of the existing `ClaimCheckReason`. That one is a numeric enum (`0` / `1`) representing the on-chain reason on `ClaimResponse`; passing it here would serialize `reason=0`, which the server rejects, and it has no way to express `agency_payout`. The naming follows `ClaimCheckTotalsStatusFilter`, which exists for the same reason. It's exported as a value, not a type, so consumers can reach the members at runtime.

This also fixes the underlying gap that blocked the feature: `getClaimCheckTotals` built its query params from an explicit whitelist, so anything not on that list was dropped before the request was sent — adding a field to the params type alone would have changed nothing.

Docs updated in the README and in the JSDoc on both the service method and the `core` entrypoint, including the two-call pattern.

## Why

Nado (Ink) needs a per-user "Rebates earned" figure. `GET /v1/claim-checks/totals` filters by user but merges affiliate commission and end-user rebate into a single number. [fuul-server#2999](https://github.com/kuyen-labs/fuul-server/pull/2999) adds the `reason` query param so the two can be requested separately; this is the SDK half of FUU-1902.

## ⚠️ Merge order

**Do not release before [fuul-server#2999](https://github.com/kuyen-labs/fuul-server/pull/2999) is deployed.** Until then the server strips `reason` via `ValidationPipe({ whitelist: true })` and silently returns merged totals — the exact failure this ticket fixes, made harder to spot because the SDK would look like it supports the param.

## Test Plan

- [x] Tested locally
- [x] Tested in staging

## Rollback Plan

Revert the commit. The change is purely additive — one optional param on one method, with no change to the response type or to behavior when `reason` is omitted — so nothing downstream depends on it and there is no data or state to unwind. Consumers already passing `reason` would simply go back to receiving merged totals.

## Checklist

- [x] Code has been tested
- [x] No secrets or credentials included in this PR
